### PR TITLE
Revert "fix domain, subdomain refs in docker-compose, TF"

### DIFF
--- a/packer/supabase/docker-compose.yml
+++ b/packer/supabase/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       PGID: 1000
       TZ: ${TIMEZONE}
       URL: ${DOMAIN}
-      SUBDOMAINS: ${SUBDOMAIN}
       VALIDATION: dns
+      SUBDOMAINS: ${SUBDOMAIN}
       DNSPLUGIN: digitalocean
       ONLY_SUBDOMAINS: true
     volumes:
-      - ./${SUBDOMAIN}.${DOMAIN}.conf:/config/nginx/proxy-confs/${SUBDOMAIN}.${DOMAIN}.conf
+      - ./${SUBDOMAIN}.subdomain.conf:/config/nginx/proxy-confs/${SUBDOMAIN}.subdomain.conf
       - ./digitalocean.ini:/config/dns-conf/digitalocean.ini
       - ./.htpasswd:/config/nginx/.htpasswd
     ports:

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -175,7 +175,7 @@ locals {
       content     = base64encode("${local.do_ini}")
     },
     {
-      path        = "/root/supabase/${var.subdomain}.${var.domain}.conf"
+      path        = "/root/supabase/${var.subdomain}.subdomain.conf"
       permissions = "0744"
       owner       = "root:root"
       encoding    = "b64"


### PR DESCRIPTION
Reverts 0reo/supabase-on-do#24

swag server looks for subdomain confs with the explicit naming convention `*.subdomain.conf`, this won't work without changing the swag docker image
